### PR TITLE
Remove ris clean-cache command from postinstall script

### DIFF
--- a/src/generators/project/package.json.hbs
+++ b/src/generators/project/package.json.hbs
@@ -9,6 +9,6 @@
   },
   "scripts": {
     "bs": "lerna bootstrap",
-    "postinstall": "lerna bootstrap && ris clean-cache"
+    "postinstall": "lerna bootstrap"
   }
 }

--- a/src/generators/project/package.json.hbs
+++ b/src/generators/project/package.json.hbs
@@ -9,6 +9,6 @@
   },
   "scripts": {
     "bs": "lerna bootstrap",
-    "postinstall": "lerna bootstrap"
+    "postinstall": "ris postinstall"
   }
 }


### PR DESCRIPTION
`ris clean-cache` will be moved to postinstall script of each plugin